### PR TITLE
Always test "latest" Node version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ node_js:
   - "5.2"
   - "5.3"
   - "5.4"
+  - "node"
+
+matrix:
+  allow_failures:
+    - node_js: "node"
 
 after_script:
   make coveralls


### PR DESCRIPTION
Tests Metalsmith with the "latest" Node version in Travis.

This test is set as an allowed failure, since Node could potentially introduce
breaking changes in new major revisions that we wouldn't want to fail new PRs
on (e.g. something broke in our already existing code), but which we would still
want to be made aware of.