### PR TITLE
Remove dest contents, but not dest. Plays nicer with simple static file servers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,7 +190,7 @@ Metalsmith.prototype.path = function(){
 Metalsmith.prototype.build = unyield(function*(){
   var clean = this.clean();
   var dest = this.destination();
-  if (clean) yield rm(dest);
+  if (clean) yield rm(path.join(dest, '*'));
 
   var files = yield this.read();
   files = yield this.run(files);


### PR DESCRIPTION
Some simple static file servers get confused when their document root vanishes out from underneath them, necessitating a restart. That makes iterative development painful.

This patch uses rimraf's globbing to only remove the contents of `dest`, not `dest` itself.