### PR TITLE
Use path.isAbsolute()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 
-var absolute = require('absolute');
 var assert = require('assert');
 var clone = require('clone');
 var fs = require('co-fs-extra');
@@ -259,7 +258,7 @@ Metalsmith.prototype.readFile = unyield(function*(file){
   var src = this.source();
   var ret = {};
 
-  if (!absolute(file)) file = path.resolve(src, file);
+  if (!path.isAbsolute(file)) file = path.resolve(src, file);
 
   try {
     var frontmatter = this.frontmatter();
@@ -332,7 +331,7 @@ Metalsmith.prototype.write = unyield(function*(files, dir){
 
 Metalsmith.prototype.writeFile = unyield(function*(file, data){
   var dest = this.destination();
-  if (!absolute(file)) file = path.resolve(dest, file);
+  if (!path.isAbsolute(file)) file = path.resolve(dest, file);
 
   try {
     yield fs.outputFile(file, data.contents);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "make test"
   },
   "dependencies": {
-    "absolute": "0.0.1",
     "async": "~0.9.0",
     "chalk": "^0.5.0",
     "clone": "^0.1.11",


### PR DESCRIPTION
For Node >= 0.12, `path.isAbsolute()` can be used instead of the `absolute` package.