### PR TITLE
Exposing ignore to CLI

### DIFF
--- a/bin/_metalsmith
+++ b/bin/_metalsmith
@@ -65,6 +65,7 @@ if (json.concurrency) metalsmith.concurrency(json.concurrency);
 if (json.metadata) metalsmith.metadata(json.metadata);
 if (json.clean != null) metalsmith.clean(json.clean);
 if (json.frontmatter != null) metalsmith.frontmatter(json.frontmatter);
+if (json.ignore != null) metalsmith.ignore(json.ignore);
 
 /**
  * Plugins.


### PR DESCRIPTION
Despite there being a `metalsmith-ignore` plugin, when dealing with `node_modules` style large directory trees it makes sense to ignore paths. That's probably why there is an `.ignore` method for the javascript API but it isn't exposed in the CLI yet.