### PR TITLE
Add the packaging metadata to build the metalsmith snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: strict
 apps:
   metalsmith:
     command: metalsmith
+    plugs: [home]
 
 parts:
   metalsmith:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: metalsmith
+version: master
+summary: An extremely simple, pluggable static site generator
+description: |
+  Metalsmith works in three simple steps:
+  1. Read all the files in a source directory.
+  2. Invoke a series of plugins that manipulate the files.
+  3. Write the results to a destination directory!
+
+grade: devel
+confinement: strict
+
+apps:
+  metalsmith:
+    command: metalsmith
+
+parts:
+  metalsmith:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.