### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "has-generators": "^1.0.1",
     "is": "^3.1.0",
     "is-utf8": "~0.2.0",
-    "recursive-readdir": "^2.0.0",
+    "recursive-readdir": "^2.1.0",
     "rimraf": "^2.2.8",
     "stat-mode": "^0.2.0",
     "thunkify": "^2.1.2",


### PR DESCRIPTION
recursive-readdir 2.0.0 depends on a version of minimatch that has a security vulnerability
This is fixed in version 2.1.0