### PR TITLE
convert makefile to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "_metalsmith": "bin/_metalsmith"
   },
   "scripts": {
-    "test": "make test"
+    "test": "_mocha",
+    "test-debug": "_mocha debug" ,
+    "coverage": "istanbul cover _mocha" ,
+    "coveralls": "npm run coverage -- --report lcovonly && coveralls < ./coverage/lcov.info "
   },
   "dependencies": {
     "absolute": "0.0.1",


### PR DESCRIPTION
as per #260 

This takes care of the tests/coveralls parts, but not the node harmony flags.

I don't have an instance of coveralls running, but it looks fine? the only thing i changed was to make it spit out lcov.info only and i doubt that is going to mess anything up.
