### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/bin/_metalsmith
+++ b/bin/_metalsmith
@@ -6,7 +6,7 @@
  * Dependencies.
  */
 
-var color = require('turbocolor').color
+var color = require('turbocolor')
 var exists = require('fs').existsSync
 var Metalsmith = require('..')
 var program = require('commander')

--- a/bin/_metalsmith
+++ b/bin/_metalsmith
@@ -6,7 +6,7 @@
  * Dependencies.
  */
 
-var chalk = require('chalk')
+var color = require('turbocolor').color
 var exists = require('fs').existsSync
 var Metalsmith = require('..')
 var program = require('commander')
@@ -119,10 +119,10 @@ metalsmith.build(function(err){
 
 function fatal(msg, stack){
   console.error()
-  console.error(chalk.red('  Metalsmith') + chalk.gray(' · ') + msg)
+  console.error(color.red('  Metalsmith') + color.gray(' · ') + msg)
   if (stack) {
     console.error()
-    console.error(chalk.gray(stack))
+    console.error(color.gray(stack))
   }
   console.error()
   process.exit(1)
@@ -136,7 +136,7 @@ function fatal(msg, stack){
 
 function log(message){
   console.log()
-  console.log(chalk.gray('  Metalsmith · ') + message)
+  console.log(color.gray('  Metalsmith · ') + message)
   console.log()
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,9 +2200,9 @@
       }
     },
     "turbocolor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-1.0.0.tgz",
-      "integrity": "sha512-aRb1cKmebkTb0BQI4re0haQ7o6ffqCLwfeSlmqbS+VWzxnzAr1FBzNxCIgU8bs0E3VvuLCXcw1dsQJGs/ajpnQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-2.0.1.tgz",
+      "integrity": "sha1-AKmOAJ3Bhzd/kLL6bxqcl+ME4OM="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,12 +93,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "ansi-wrap": {
       "version": "0.1.0",
@@ -277,6 +279,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -547,7 +550,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.8.1",
@@ -1002,6 +1006,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -2069,6 +2074,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -2082,7 +2088,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "table": {
       "version": "4.0.2",
@@ -2191,6 +2198,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "turbocolor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-1.0.0.tgz",
+      "integrity": "sha512-aRb1cKmebkTb0BQI4re0haQ7o6ffqCLwfeSlmqbS+VWzxnzAr1FBzNxCIgU8bs0E3VvuLCXcw1dsQJGs/ajpnQ=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "./node_modules/.bin/eslint index.js lib/* bin/* test/*.js"
   },
   "dependencies": {
-    "turbocolor": "^1.0.0",
+    "turbocolor": "^2.0.1",
     "clone": "^2.1.1",
     "co-fs-extra": "^1.2.1",
     "commander": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "./node_modules/.bin/eslint index.js lib/* bin/* test/*.js"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
+    "turbocolor": "^1.0.0",
     "clone": "^2.1.1",
     "co-fs-extra": "^1.2.1",
     "commander": "^2.6.0",


### PR DESCRIPTION
Hi @Ajedi32, @Zearin! 👋 

This PR swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor).

Turbocolor will give you a small perf boost as it loads _>20x_ faster and applies styles _>18x_ faster than chalk for the same API.

<pre>
# Load Time
chalk: 15.190ms
turbocolor: 0.777ms

# All Colors
chalk × 8,729 ops/sec
turbocolor × 158,383 ops/sec

# Chained Colors
chalk × 1,838 ops/sec
turbocolor × 39,830 ops/sec

# Nested Colors
chalk × 4,049 ops/sec
turbocolor × 59,833 ops/sec
</pre>

Cheers!