### PR TITLE
Bump gray-matter from 2.1.1 to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "^2.1.1",
     "co-fs-extra": "^1.2.1",
     "commander": "~2.15.1",
-    "gray-matter": "^2.1.1",
+    "gray-matter": "^4.0.3",
     "has-generators": "^1.0.1",
     "is-utf8": "~0.2.0",
     "recursive-readdir": "^2.1.0",


### PR DESCRIPTION
Dropped support for `node v0.12` and engines (previously parsers) `toml`, `coffee` and `cson`.

More details at https://github.com/jonschlinkert/gray-matter/blob/HEAD/CHANGELOG.md