### PR TITLE
examples: replace makefiles with npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![npm version][npm-badge]][npm-url]
 [![Build Status][travis-badge]][travis-url]
 [![Coverage Status][coveralls-badge]][coveralls-url]
-[![Slack chat][slack-badge]][slack-url]
 
 > An extremely simple, _pluggable_ static site generator.
 
@@ -294,5 +293,3 @@ This project is no longer maintained by Segment. Instead, [Andrew Goodricke](htt
 [travis-url]: https://travis-ci.org/segmentio/metalsmith
 [coveralls-badge]:https://coveralls.io/repos/segmentio/metalsmith/badge.svg?branch=master&service=github
 [coveralls-url]: https://coveralls.io/github/segmentio/metalsmith?branch=master
-[slack-badge]: https://img.shields.io/badge/Slack-Join%20Chat%20→-blue.svg
-[slack-url]: http://metalsmith-slack.herokuapp.com/

--- a/examples/build-tool/Makefile
+++ b/examples/build-tool/Makefile
@@ -1,8 +1,0 @@
-
-build: node_modules
-	node build.js
-
-node_modules: package.json
-	npm install
-
-.PHONY: build

--- a/examples/build-tool/Readme.md
+++ b/examples/build-tool/Readme.md
@@ -1,11 +1,8 @@
-
 # build-tool
 
 This example uses Metalsmith to make a simple build tool for CSS files. To test it out yourself run:
 
-    $ npm install
-    $ node build.js
-
-Or simply:
-
-    $ make build
+```bash
+npm install
+npm run build
+```

--- a/examples/build-tool/package.json
+++ b/examples/build-tool/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "myth": "^0.3.0",
     "metalsmith": "^1.0.0"
+  },
+  "scripts": {
+    "build": "node build.js"
   }
 }

--- a/examples/drafts-plugin/Readme.md
+++ b/examples/drafts-plugin/Readme.md
@@ -1,4 +1,3 @@
-
 # drafts-plugin
 
 This is an example of how simple a plugin can be for metalsmith. It just hides files that are marked as drafts.

--- a/examples/jekyll/Makefile
+++ b/examples/jekyll/Makefile
@@ -1,4 +1,0 @@
-build: 
-	npm install && npm run build
-
-.PHONY: build

--- a/examples/project-scaffolder/Makefile
+++ b/examples/project-scaffolder/Makefile
@@ -1,8 +1,0 @@
-
-build: node_modules
-	node build.js
-
-node_modules: package.json
-	npm install
-
-.PHONY: build

--- a/examples/project-scaffolder/Readme.md
+++ b/examples/project-scaffolder/Readme.md
@@ -1,11 +1,8 @@
-
 # project-scaffolder
 
 This example uses Metalsmith to make a node project scaffolder that prompts you to enter a bit of information about your project, and then creates the new project directory for you. To test it out yourself run:
 
-    $ npm install
-    $ node build.js
-
-Or simply:
-
-    $ make build
+```bash
+npm install
+npm run build
+```

--- a/examples/project-scaffolder/package.json
+++ b/examples/project-scaffolder/package.json
@@ -7,5 +7,8 @@
     "handlebars": "^2.0.0-alpha.2",
     "cli-prompt": "^0.3.2",
     "metalsmith": "^1.0.0"
+  },
+  "scripts": {
+    "build": "node build.js"
   }
 }

--- a/examples/wintersmith/Makefile
+++ b/examples/wintersmith/Makefile
@@ -1,8 +1,0 @@
-
-build: node_modules
-	node_modules/.bin/metalsmith
-
-node_modules: package.json
-	npm install
-
-.PHONY: build

--- a/examples/wintersmith/Readme.md
+++ b/examples/wintersmith/Readme.md
@@ -3,4 +3,7 @@
 
 This example uses Metalsmith to emulate a Wintersmith static site. To test it out yourself just run:
 
-    $ make build
+```bash
+npm install
+npm run build
+```


### PR DESCRIPTION
The examples all used Makefiles, but it's more conventional for Node.js to have NPM scripts for maintaining or sharing commands.

This replaces the Makefiles and removes the "requirement" to have `make` installed for an NPM script which does the same thing.

Also removes the link to Slack from the README. (Related to https://github.com/metalsmith/metalsmith/commit/0bea2ac0db47ebeab10e9c6a45653bf6eb7ee4ea)