### PR TITLE
chores: replace plugin objects with plugin arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,11 @@ be published to the world, you can include plugins as local npm modules:
 
 ```json
 {
-  "plugins": {
-    "./lib/metalsmith/plugin.js": true
-  }
+  "plugins": [
+    {
+      "./lib/metalsmith/plugin.js": true
+    }
+  ]
 }
 ```
 

--- a/examples/jekyll/metalsmith.json
+++ b/examples/jekyll/metalsmith.json
@@ -5,15 +5,23 @@
     "title": "My Jekyll-Powered Blog",
     "description": "My second, super-cool, Jekyll-powered blog."
   },
-  "plugins": {
-    "metalsmith-drafts": {},
-    "metalsmith-markdown": {},
-    "metalsmith-permalinks": {
-      "pattern": ":title"
+  "plugins": [
+    {
+      "metalsmith-drafts": {}
     },
-    "metalsmith-layouts": {
-      "engine": "swig",
-      "directory": "_layouts"
+    {
+      "metalsmith-markdown": {}
+    },
+    {
+      "metalsmith-permalinks": {
+        "pattern": ":title"
+      }
+    },
+    {
+      "metalsmith-layouts": {
+        "engine": "swig",
+        "directory": "_layouts"
+      }
     }
-  }
+  ]
 }

--- a/examples/wintersmith/metalsmith.json
+++ b/examples/wintersmith/metalsmith.json
@@ -4,14 +4,19 @@
     "title": "My Wintersmith-Powered Blog",
     "description": "My second, super-cool, Wintersmith-powered blog."
   },
-  "plugins": {
-    "metalsmith-markdown": {},
-    "metalsmith-permalinks": {
-      "pattern": ":title"
+  "plugins": [
+    {
+      "metalsmith-markdown": {}
     },
-    "metalsmith-layouts": {
-      "engine": "jade",
-      "directory": "./templates"
+    {
+      "metalsmith-permalinks": {
+        "pattern": ":title"
+      }
+    },
+    {
+      "metalsmith-layouts": {
+        "directory": "layouts"
+      }
     }
-  }
+  ]
 }

--- a/test/fixtures/cli-broken-plugin/metalsmith.json
+++ b/test/fixtures/cli-broken-plugin/metalsmith.json
@@ -1,5 +1,7 @@
 {
-  "plugins": {
-    "./plugin": true
-  }
+  "plugins": [
+    {
+      "./plugin": true
+    }
+  ]
 }

--- a/test/fixtures/cli-no-plugin/metalsmith.json
+++ b/test/fixtures/cli-no-plugin/metalsmith.json
@@ -1,5 +1,7 @@
 {
-  "plugins": {
-    "metalsmith-non-existant": {}
-  }
+  "plugins": [
+    {
+      "metalsmith-non-existant": {}
+    }
+  ]
 }

--- a/test/fixtures/cli-plugin-local/metalsmith.json
+++ b/test/fixtures/cli-plugin-local/metalsmith.json
@@ -1,5 +1,7 @@
 {
-  "plugins": {
-    "./plugin": true
-  }
+  "plugins": [
+    {
+      "./plugin": true
+    }
+  ]
 }


### PR DESCRIPTION
Replaces all instances of the `plugins: {}` with `plugins: []` except where it's explicitly showcasing the use of an object, for example:
* `README.md` (one instance here)
* `test/fixtures/cli-plugin-object/metalsmith.json` (this is a test to check that it parses objects correctly)

Relates to:
* https://github.com/metalsmith/metalsmith/issues/223
* https://github.com/metalsmith/metalsmith/issues/129