### PR TITLE
docs: pad spaces around json object

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ You can specify your plugins as either an object or array. Using an array would 
   "source": "src",
   "destination": "build",
   "plugins": [
-    {"metalsmith-drafts": true},
-    {"metalsmith-markdown": true},
-    {"metalsmith-permalinks": "posts/:title"},
-    {"metalsmith-templates": "handlebars"}
+    { "metalsmith-drafts": true },
+    { "metalsmith-markdown": true },
+    { "metalsmith-permalinks": "posts/:title" },
+    { "metalsmith-layouts": true }
   ]
 }
 ```


### PR DESCRIPTION
What you had before isn't invalid, but it looks cleaner this way anyway.

The motivation behind making a PR out of it though is because the syntax highlighting GitHub uses doesn't process it correctly.

![image](https://user-images.githubusercontent.com/22801583/142760327-5ad19785-740b-45f3-a524-f3bf3c38d7fc.png)

### Before
```json
{
  "source": "src",
  "destination": "build",
  "plugins": [
    {"metalsmith-drafts": true},
    {"metalsmith-markdown": true},
    {"metalsmith-permalinks": "posts/:title"},
    {"metalsmith-templates": "handlebars"}
  ]
}
```

### After
```json
{
  "source": "src",
  "destination": "build",
  "plugins": [
    { "metalsmith-drafts": true },
    { "metalsmith-markdown": true },
    { "metalsmith-permalinks": "posts/:title" },
    { "metalsmith-layouts": true }
  ]
}
```

---

While I was at it, I replaced `"metalsmith-templates": "handlebars"` with `"metalsmith-layouts": true` since `metalsmith-templates` is deprecated.