### PR TITLE
Avoid leaking unhandled rejections

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -447,6 +447,7 @@ Metalsmith.prototype.build = function (callback) {
           if (err) {
             if (isFunction(callback)) {
               callback(err)
+              return
             }
             reject(err)
             return
@@ -555,7 +556,7 @@ Metalsmith.prototype.process = function (callback) {
       const msWatcher = watcher(files, this)
       msWatcher(this[symbol.watch], callback).then((close) => {
         this[symbol.closeWatcher] = close
-      })
+      }, callback)
     })
   } else {
     result = result.then((files) => this.run(files, this.plugins))


### PR DESCRIPTION
Fixes #393.

Previously the callback-based API leaked unhandled rejections in two places:
1. After calling the callback, it rejected the unreturned promise, which is never handled. This is fixed by returning between the callback and the reject.
2. While watching, the first build unexpectedly returns a promise reflecting the initial result. If it's failed, it's likely to go unhandled, but also doesn't ever call the callback anyway. This is fixed by passing the callback for failures, such that the returned promise is the (probably-successful) result of the callback, rather than the error itself.